### PR TITLE
Add MoonMaker API — x402 pay-per-call crypto intelligence

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,67 @@
+Awesome Cryptocurrency API
+==========================
+
+Cryptocurrency general data
+---------------------------
+`Coinpaprika <https://api.coinpaprika.com/>`_ Provides extensive data for free. 
+
+`CoinAPI <https://www.coinapi.io/>`_ – Advertises itself as a "one-stop solutin market data provider for cryptocurrency markets."
+
+`CryptoCompare <https://min-api.cryptocompare.com/>`_ "The ultimate API solution."
+
+`CoinMarketCap <https://coinmarketcap.com/api/>`_ Live price streaming, whitepaper search, charts snapshot and more.
+
+`Nomics <https://p.nomics.com/cryptocurrency-bitcoin-api>`_ Claims to be the best API for cryptocurrency market data.
+
+`Coinlayer <https://coinlayer.com/>`_ Real-time cryptocurrency exchange reates
+
+`CoinGecko <https://www.coingecko.com/en/api>`_ Advertises itself as "The world's most comprehensive cryptocurrency data API."
+
+`Cryptonator <https://www.cryptonator.com/api>`_ Exchange rates API.
+
+`BraveNewCoin <https://bravenewcoin.com/>`_ Provides exchange-level, standardised raw data via a single websocket API, offering near real-time streaming of price and volume data from over 240 exchanges.
+
+`Coinigy <https://www.coinigy.com/bitcoin-api/>`_ Advertises itself as the "The All-In-One Cryptocurrency API."
+
+`Coinograph <https://coinograph.io/>`_ Provides real-time and historical cryptocurrency market data.
+
+`Kaiko <https://www.kaiko.com/>`_ Claims to be "the leading provider of institutional grade cryptocurrency market data."
+
+`Blockmarkets <https://www.blockmarkets.io/>`_ Advertises itself as providing "institutional-grade cryptocurrency market data to funds, investment professionals, and application developers."
+
+`Coinlib <https://coinlib.io/apidocs/>`_ Simple API for fetching coin prices and global market data.
+
+`Coinscious <https://coinscious.io/>`_ Claims to be the "The Most Accurate Cryptocurrency Market Data API."
+
+`Coindar <https://coindar.org/en/api/>`_ Provides an API for fetching events.
+
+`CoinCap <https://docs.coincap.io/>`_ Real-time pricing and market activity API.
+
+`BitDataset <https://bitdataset.com/api/>`_ Provides cryptocurrency trade/quote/order book historical data.
+
+`Zloadr <https://www.zloadr.com/cryptocurrency-api/cryptocurrency-data-api.php>`_ Paid plans provide due diligence scoring, real time news and historical data up to 5 years.
+
+`DataLight <https://docs.datalight.me/public-api/welcome>`_ Extensive amount of coins, allows you to fetch it all in one HTTP request.
+
+`Delta <https://delta.app/en/api>`_ Real-time pricing API.
+
+
+Sentiment data APIs
+-------------------
+`Santiment <https://santiment.net/>`_ 1200+ assets tracked, claims to have the "most accurate updates on daily crypto trends."
+
+`Predicoin <https://predicoin.com/>`_ Claims to provide sentiment data from over 100 news sources.
+
+`Bittsanalytics <https://predicoin.com/>`_ Claims it's "trusted by many hedge funds and individual clients" and to analyze millions of social media posts every day.
+
+`Mosaic.io <https://www.mosaic.io/#API>`_ Comprehensive cryptoasset coverage.
+
+`Decryptz <https://decryptz.com/#>`_ Enterprise grade data, claims to provide the "highest caliber crypto sentiment data API in the industry."
+
+`CryptoQokka <https://cryptoqokka.com/developer>`_ Market sentiment overview, price and sentiment charts, news with analysis, raw data and more.
+
+`Daneel <https://daneel.io/>`_ Provides market news, trending news, volume news, hot news, global sentiment, market sentiment, gainers and losers and more.
+
+
+
+- [MoonMaker API](https://api.moonmaker.cc) - AI-native crypto data API with x402 pay-per-call. 11 endpoints: signals, regime, institutions, ETF flows, DeFi yields & DEX alpha. $0.02–$0.10/call USDC on Base. No signup. [llms.txt](https://api.moonmaker.cc/llms.txt)

--- a/README.md
+++ b/README.md
@@ -65,3 +65,4 @@ Sentiment data APIs
 
 
 - [MoonMaker API](https://api.moonmaker.cc) - AI-native crypto data API with x402 pay-per-call. 11 endpoints: signals, regime, institutions, ETF flows, DeFi yields & DEX alpha. $0.02–$0.10/call USDC on Base. No signup. [llms.txt](https://api.moonmaker.cc/llms.txt)
+- [MoonMaker API](https://api.moonmaker.cc) - AI-native crypto data API with x402 pay-per-call. 11 endpoints: signals, regime, institutions, ETF flows, DeFi yields & DEX alpha. $0.02–$0.10/call USDC on Base. No signup. [llms.txt](https://api.moonmaker.cc/llms.txt)


### PR DESCRIPTION
## Add MoonMaker API

[MoonMaker API](https://api.moonmaker.cc) is a live x402 pay-per-call crypto intelligence API built for AI agents.

- 11 endpoints: signals, context, regime, risk, institutions, ETF, yields, DEX alpha
- $0.02–$0.10 USDC per call on Base mainnet
- No signup or API key — pure x402
- AI agent discovery via [llms.txt](https://api.moonmaker.cc/llms.txt)
- Live since Feb 2026